### PR TITLE
Add client-side heartbeats.

### DIFF
--- a/korolev/src/main/es6/bridge.js
+++ b/korolev/src/main/es6/bridge.js
@@ -18,14 +18,14 @@ export class Bridge {
 
     connection.dispatcher.addEventListener("message", this._messageHandler);
 
-    !function(cn, ping, cfg) {
-      var period = parseInt(cfg['heartbeatPeriod'], 10)
+    ((cn, ping, cfg) => {
+      const period = parseInt(cfg['keepAliveInterval'], 10)
       if (period > 0) {
-        setInterval(function () {
+        setInterval(() => {
           ping(CallbackType.HEARTBEAT, "beep")
         }, period)
       }
-    }(this._connection, this._onCallback.bind(this), config)
+    })(this._connection, this._onCallback.bind(this), config)
   }
 
   /**

--- a/korolev/src/main/es6/bridge.js
+++ b/korolev/src/main/es6/bridge.js
@@ -17,6 +17,15 @@ export class Bridge {
     this._messageHandler = this._onMessage.bind(this);
 
     connection.dispatcher.addEventListener("message", this._messageHandler);
+
+    !function(cn, ping, cfg) {
+      var period = parseInt(cfg['heartbeatPeriod'], 10)
+      if (period > 0) {
+        setInterval(function () {
+          ping(CallbackType.HEARTBEAT, "beep")
+        }, period)
+      }
+    }(this._connection, this._onCallback.bind(this), config)
   }
 
   /**

--- a/korolev/src/main/es6/korolev.js
+++ b/korolev/src/main/es6/korolev.js
@@ -5,7 +5,8 @@ export const CallbackType = {
   DOM_EVENT: 0, // `$renderNum:$elementId:$eventType`
   FORM_DATA_PROGRESS: 1, // `$descriptor:$loaded:$total`
   EXTRACT_PROPERTY_RESPONSE: 2, // `$descriptor:$value`
-  HISTORY: 3  // URL
+  HISTORY: 3, // URL
+  HEARTBEAT: 4 // Client side keep-alive messages
 };
 
 export const PropertyType = {

--- a/korolev/src/main/scala/korolev/internal/ClientSideApi.scala
+++ b/korolev/src/main/scala/korolev/internal/ClientSideApi.scala
@@ -162,6 +162,8 @@ final class ClientSideApi[F[+ _]: Async](connection: Connection[F])
             .foreach(_.complete(result))
         case CallbackType.History.code =>
           onHistory(Router.Path.fromString(args))
+        case CallbackType.Heartbeat.code =>
+          // Client is still alive, keep working hard
       }
       onReceive()
     case Failure(e) =>
@@ -228,8 +230,9 @@ object ClientSideApi {
     case object FormDataProgress extends CallbackType(1) // `$descriptor:$loaded:$total`
     case object ExtractPropertyResponse extends CallbackType(2) // `$descriptor:$value`
     case object History extends CallbackType(3) // URL
+    case object Heartbeat extends CallbackType(4) // Client side keep-alive messages
 
-    final val All = Set(DomEvent, FormDataProgress, ExtractPropertyResponse, History)
+    final val All = Set(DomEvent, FormDataProgress, ExtractPropertyResponse, History, Heartbeat)
 
     def apply(n: Int): Option[CallbackType] =
       All.find(_.code == n)

--- a/server/akkahttp/src/main/scala/korolev/akkahttp/package.scala
+++ b/server/akkahttp/src/main/scala/korolev/akkahttp/package.scala
@@ -16,7 +16,6 @@ import korolev.execution.defaultExecutor
 import korolev.server.{KorolevService, KorolevServiceConfig, MimeTypes, Request => KorolevRequest, Response => KorolevResponse}
 import korolev.state.{StateDeserializer, StateSerializer}
 
-import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
 
 package object akkahttp {
@@ -28,18 +27,19 @@ package object akkahttp {
       (implicit actorSystem: ActorSystem, materializer: Materializer): AkkaHttpService = { akkaHttpConfig =>
     val korolevServer = korolev.server.korolevService(mimeTypes, config)
 
-    webSocketRoute(korolevServer, akkaHttpConfig) ~
+    webSocketRoute(korolevServer, akkaHttpConfig, config) ~
       httpGetRoute(korolevServer) ~
       httpPostRoute(korolevServer)
   }
 
-  private val KeepAliveInterval = 5.seconds
   private val KeepAliveMessage = TextMessage("[9]")
 
-  private def webSocketRoute[F[+_]: Async](korolevServer: KorolevService[F],
-                                           akkaHttpConfig: AkkaHttpServerConfig)
-                                          (implicit actorSystem: ActorSystem,
-                                                    materializer: Materializer): Route =
+  private def webSocketRoute[F[+_]: Async, S: StateSerializer: StateDeserializer, M]
+      (korolevServer: KorolevService[F],
+       akkaHttpConfig: AkkaHttpServerConfig,
+       korolevServiceConfig: KorolevServiceConfig[F, S, M])
+                        (implicit actorSystem: ActorSystem,
+                                  materializer: Materializer): Route =
     extractRequest { request =>
       extractUnmatchedPath { path =>
         extractUpgradeToWebSocket { upgrade =>
@@ -58,7 +58,7 @@ package object akkahttp {
                       actorRef ! TextMessage(message)
                     }
                   }
-                  .keepAlive(KeepAliveInterval, () => KeepAliveMessage)
+                  .keepAlive(korolevServiceConfig.keepAliveInterval, () => KeepAliveMessage)
 
               complete(upgrade.handleMessagesWithSinkSource(in, out))
             case _ =>

--- a/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
+++ b/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
@@ -16,7 +16,8 @@ case class KorolevServiceConfig[F[+_]: Async, S, M](
   envConfigurator: EnvConfigurator[F, S, M] =
     (_: String, _: String, _: ApplyTransition[F, S]) =>
       Env(onDestroy = () => (), PartialFunction.empty),
-  idGenerator: IdGenerator[F] = IdGenerator.default[F]()
+  idGenerator: IdGenerator[F] = IdGenerator.default[F](),
+  heartbeatPeriod: Int = 5000
 )
 
 object KorolevServiceConfig {

--- a/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
+++ b/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
@@ -4,6 +4,7 @@ import korolev.server.KorolevServiceConfig.{ApplyTransition, Env, EnvConfigurato
 import korolev.state.IdGenerator
 import korolev.{Async, Context, Transition}
 import levsha.{Document, TemplateDsl}
+import scala.concurrent.duration._
 
 case class KorolevServiceConfig[F[+_]: Async, S, M](
   stateStorage: korolev.state.StateStorage[F, S],
@@ -17,7 +18,7 @@ case class KorolevServiceConfig[F[+_]: Async, S, M](
     (_: String, _: String, _: ApplyTransition[F, S]) =>
       Env(onDestroy = () => (), PartialFunction.empty),
   idGenerator: IdGenerator[F] = IdGenerator.default[F](),
-  heartbeatPeriod: Int = 5000
+  keepAliveInterval: FiniteDuration = 5.seconds
 )
 
 object KorolevServiceConfig {

--- a/server/base/src/main/scala/korolev/server/package.scala
+++ b/server/base/src/main/scala/korolev/server/package.scala
@@ -56,6 +56,7 @@ package object server extends LazyLogging {
         val dsl = new levsha.TemplateDsl[Context.Effect[F, S, M]]()
         val textRenderContext = new HtmlRenderContext[F, S, M]()
         val rootPath = config.serverRouter.rootPath
+        val heartbeatPeriod = config.heartbeatPeriod
         val clw = {
           val textRenderContext = new HtmlRenderContext[F, S, M]()
           config.connectionLostWidget(textRenderContext)
@@ -64,9 +65,10 @@ package object server extends LazyLogging {
 
         import dsl._
 
+        val kfg = s"window['kfg']={sid:'$sessionId',r:'$rootPath',clw:'$clw',heartbeatPeriod:$heartbeatPeriod}"
         val document = 'html(
           'head(
-            'script('language /= "javascript", s"window['kfg']={sid:'$sessionId',r:'$rootPath',clw:'$clw'}"),
+            'script('language /= "javascript", kfg),
             'script('src /= config.serverRouter.rootPath + "korolev-client.min.js"),
             config.head
           ),

--- a/server/base/src/main/scala/korolev/server/package.scala
+++ b/server/base/src/main/scala/korolev/server/package.scala
@@ -56,7 +56,7 @@ package object server extends LazyLogging {
         val dsl = new levsha.TemplateDsl[Context.Effect[F, S, M]]()
         val textRenderContext = new HtmlRenderContext[F, S, M]()
         val rootPath = config.serverRouter.rootPath
-        val heartbeatPeriod = config.heartbeatPeriod
+        val keepAliveInterval = config.keepAliveInterval.toMillis
         val clw = {
           val textRenderContext = new HtmlRenderContext[F, S, M]()
           config.connectionLostWidget(textRenderContext)
@@ -65,7 +65,7 @@ package object server extends LazyLogging {
 
         import dsl._
 
-        val kfg = s"window['kfg']={sid:'$sessionId',r:'$rootPath',clw:'$clw',heartbeatPeriod:$heartbeatPeriod}"
+        val kfg = s"window['kfg']={sid:'$sessionId',r:'$rootPath',clw:'$clw',keepAliveInterval:$keepAliveInterval}"
         val document = 'html(
           'head(
             'script('language /= "javascript", kfg),


### PR DESCRIPTION
Some proxies (like gcloud ssl termination proxy) count idleness for both
sides. So although we have permanent periodical server originated
messages that proxies FIN connections due to client idleness.

Just add one more callback type for a single purpose to signal that
client is still alive and needs attention.

This patch had been tested with google cloud's SSL load balancer.