### PR TITLE
Add client-side heartbeats.

### DIFF
--- a/korolev/src/main/es6/bridge.js
+++ b/korolev/src/main/es6/bridge.js
@@ -17,6 +17,12 @@ export class Bridge {
     this._messageHandler = this._onMessage.bind(this);
 
     connection.dispatcher.addEventListener("message", this._messageHandler);
+
+    let interval = parseInt(config['heartbeatInterval'], 10);
+
+    if (interval > 0) {
+      setInterval(() => this._onCallback(CallbackType.HEARTBEAT, "beep"), interval)
+    }
   }
 
   /**

--- a/korolev/src/main/es6/korolev.js
+++ b/korolev/src/main/es6/korolev.js
@@ -7,7 +7,8 @@ export const CallbackType = {
   EXTRACT_PROPERTY_RESPONSE: 2, // `$descriptor:$propertyType:$value`
   HISTORY: 3, // URL
   EVALJS_RESPONSE: 4, // `$descriptor:$status:$value`
-  EXTRACT_EVENT_DATA_RESPONSE: 5 // `$descriptor:$dataJson`
+  EXTRACT_EVENT_DATA_RESPONSE: 5, // `$descriptor:$dataJson`
+  HEARTBEAT: 6 // `$descriptor:$anyvalue`
 };
 
 /** @enum {number} */

--- a/korolev/src/main/scala/korolev/internal/ClientSideApi.scala
+++ b/korolev/src/main/scala/korolev/internal/ClientSideApi.scala
@@ -273,8 +273,9 @@ object ClientSideApi {
     case object History extends CallbackType(3) // URL
     case object EvalJsResponse extends CallbackType(4) // `$descriptor:$status:$value`
     case object ExtractEventDataResponse extends CallbackType(5) // `$descriptor:$dataJson`
+    case object Heartbeat extends CallbackType(6) // `$descriptor:$anyvalue`
 
-    final val All = Set(DomEvent, FormDataProgress, ExtractPropertyResponse, History, EvalJsResponse, ExtractEventDataResponse)
+    final val All = Set(DomEvent, FormDataProgress, ExtractPropertyResponse, History, EvalJsResponse, ExtractEventDataResponse, Heartbeat)
 
     def apply(n: Int): Option[CallbackType] =
       All.find(_.code == n)

--- a/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
+++ b/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
@@ -3,6 +3,7 @@ package korolev.server
 import korolev.state.{DeviceId, EnvConfigurator, IdGenerator, SessionId}
 import korolev.{Async, Context, Router}
 import levsha.{Document, TemplateDsl}
+import scala.concurrent.duration._
 
 case class KorolevServiceConfig[F[+_]: Async, S, M](
   stateStorage: korolev.state.StateStorage[F, S],
@@ -14,7 +15,8 @@ case class KorolevServiceConfig[F[+_]: Async, S, M](
     KorolevServiceConfig.defaultConnectionLostWidget[Context.Effect[F, S, M]],
   maxFormDataEntrySize: Int = 1024 * 1024 * 8,
   envConfigurator: EnvConfigurator[F, S, M] = EnvConfigurator.default[F, S, M],
-  idGenerator: IdGenerator[F] = IdGenerator.default[F]()
+  idGenerator: IdGenerator[F] = IdGenerator.default[F](),
+  heartbeatInterval: FiniteDuration = 5.seconds
 )
 
 object KorolevServiceConfig {

--- a/server/base/src/main/scala/korolev/server/package.scala
+++ b/server/base/src/main/scala/korolev/server/package.scala
@@ -60,12 +60,14 @@ package object server extends LazyLogging {
           config.connectionLostWidget(textRenderContext)
           textRenderContext.mkString
         }
+        val heartbeatInterval = config.heartbeatInterval.toMillis
 
         import dsl._
 
+        val kfg = s"window['kfg']={sid:'$sessionId',r:'$rootPath',clw:'$clw',heartbeatInterval:$heartbeatInterval}"
         val document = 'html(
           'head(
-            'script('language /= "javascript", s"window['kfg']={sid:'$sessionId',r:'$rootPath',clw:'$clw'}"),
+            'script('language /= "javascript", kfg),
             'script('src /= config.rootPath + "korolev-client.min.js"),
             config.head
           ),

--- a/server/blaze/src/main/scala/korolev/blazeServer/package.scala
+++ b/server/blaze/src/main/scala/korolev/blazeServer/package.scala
@@ -15,7 +15,6 @@ import org.http4s.blaze.pipeline.{Command, LeafBuilder}
 import org.http4s.websocket.WebsocketBits._
 
 import scala.concurrent.Promise
-import scala.concurrent.duration._
 
 package object blazeServer {
 
@@ -75,7 +74,7 @@ package object blazeServer {
           HttpResponse(status.code, status.phrase, responseHeaders, ByteBuffer.wrap(body))
         case KorolevResponse.WebSocket(publish, subscribe, destroy) =>
           val stage = new WebSocketStage {
-            val stopHeartbeat = Scheduler[F].schedule(5.seconds) {
+            val stopHeartbeat = Scheduler[F].schedule(config.heartbeatInterval) {
               channelWrite(Ping())
             }
             def destroyAndStopTimer(): Unit = {


### PR DESCRIPTION
Some proxies (like gcloud ssl termination proxy) count idleness for both
sides. So although we have permanent periodical server originated
messages that proxies FIN connections due to client idleness.

Add one more callback type for a single purpose to signal that
client is still alive and needs attention. Unify client/server
heartbeats interval config.

This patch had been tested with google cloud's SSL load balancer.