### PR TITLE
Fix event subscription when using lazy async.

### DIFF
--- a/server/base/src/main/scala/korolev/server/package.scala
+++ b/server/base/src/main/scala/korolev/server/package.scala
@@ -166,7 +166,9 @@ package object server extends LazyLogging {
       } yield {
 
         // Subscribe to events to publish them to env
-        korolev.topLevelComponentInstance.setEventsSubscription(env.onMessage)
+        korolev.topLevelComponentInstance.setEventsSubscription { message: M =>
+          env.onMessage(message).runIgnoreResult
+        }
 
         new KorolevSession[F] {
 


### PR DESCRIPTION
Needed to run it explicitly for lazy `F`s (like Monix `Task`).