### PR TITLE
Close #248: Specify device id cookie path

### DIFF
--- a/server/base/src/main/scala/korolev/server/package.scala
+++ b/server/base/src/main/scala/korolev/server/package.scala
@@ -104,7 +104,7 @@ package object server {
           status = Response.Status.Ok,
           headers = Seq(
             "content-type" -> htmlContentType,
-            "set-cookie" -> s"${Cookies.DeviceId}=$deviceId"
+            "set-cookie" -> s"${Cookies.DeviceId}=$deviceId; Path=${config.rootPath}"
           ),
           body = Some {
             val sb = mutable.StringBuilder.newBuilder


### PR DESCRIPTION
Prevents setting multiple cookies for sub-paths.