### PR TITLE
long-polling: HTTP 503 is timeout, not a failure

### DIFF
--- a/korolev/src/main/es6/connection.js
+++ b/korolev/src/main/es6/connection.js
@@ -112,6 +112,7 @@ export class Connection {
             if (firstTime)
               this._onOpen();
             this._onMessage(request.responseText);
+          case 503:
             // Poll again
             subscribe(false);
             break;


### PR DESCRIPTION
akka-http closes timed out long-polling requests with HTTP code 503.
The client should retry on 503.