### PR TITLE
stop heartbeating in Bridge.destroy()

### DIFF
--- a/korolev/src/main/es6/bridge.js
+++ b/korolev/src/main/es6/bridge.js
@@ -21,7 +21,7 @@ export class Bridge {
     let interval = parseInt(config['heartbeatInterval'], 10);
 
     if (interval > 0) {
-      setInterval(() => this._onCallback(CallbackType.HEARTBEAT), interval);
+      this._intervalId = setInterval(() => this._onCallback(CallbackType.HEARTBEAT), interval);
     }
   }
 
@@ -61,6 +61,7 @@ export class Bridge {
   }
 
   destroy() {
+    clearInterval(this._intervalId);
     this._connection.dispatcher.removeEventListener("message", this._messageHandler);
     this._korolev.destroy();
   }


### PR DESCRIPTION
On each websocket reconnection, the number of leaked timers grow by 1.
As newly created `Bridge` objects are sharing the same connection object, the timers are not only leaked, they all do send heartbeat messages.