### PR TITLE
Do not update the value of a focused text input as the user may be typing

### DIFF
--- a/korolev/src/main/es6/korolev.js
+++ b/korolev/src/main/es6/korolev.js
@@ -250,6 +250,15 @@ export class Korolev {
     */
   setAttr(id, xmlNs, name, value, isProperty) {
     var element = this.els[id];
+
+     // Do not update the value of a focused text input as the user may be typing a value into it at this moment
+     var isFocused = (document.activeElement === element);
+     if (isFocused) {
+       var isInputText = element instanceof HTMLInputElement && element.type == 'text';
+       if (isInputText)
+         return;
+     }
+
     if (isProperty) element[name] = value;
     else if (xmlNs === 0) {
       element.setAttribute(name, value);


### PR DESCRIPTION
When a user is typing on a text field, if the value is updated dynamically from the server then it over-writes the value the user is typing. The user entering the text should have priority, so in this case if the user has a focused text entry field then do no update its value.