### PR TITLE
Close #268: Don't pass Korolev's internal paths to Router.toState

### DIFF
--- a/server/akkahttp/src/main/scala/korolev/akkahttp/package.scala
+++ b/server/akkahttp/src/main/scala/korolev/akkahttp/package.scala
@@ -117,7 +117,7 @@ package object akkahttp {
 
   private def httpPostRoute[F[_]](korolevServer: KorolevService[F])(implicit mat: Materializer, async: Async[F]): Route =
     post {
-      extractRequest { request =>
+      extractRequest { _ =>
         extractUnmatchedPath { path =>
           parameterMap { params =>
             extractRequest { request =>
@@ -154,9 +154,9 @@ package object akkahttp {
     }
 
   private def mkKorolevRequest[F[_]](request: HttpRequest,
-                                            path: String,
-                                            params: Map[String, String],
-                                            body: LazyBytes[F])
+                                     path: String,
+                                     params: Map[String, String],
+                                     body: LazyBytes[F])
                                     (implicit async: Async[F]): KorolevRequest[F] =
     KorolevRequest(
       path = Router.Path.fromString(path),
@@ -173,7 +173,7 @@ package object akkahttp {
     )
 
   private def handleHttpResponse[F[_]: Async](korolevServer: KorolevService[F],
-                                               korolevRequest: KorolevRequest[F]): Future[HttpResponse] =
+                                              korolevRequest: KorolevRequest[F]): Future[HttpResponse] =
     asyncToFuture(korolevServer(korolevRequest)).map {
       case KorolevResponse.Http(status, streamOpt, responseHeaders) =>
         val (contentTypeOpt, otherHeaders) = getContentTypeAndResponseHeaders(responseHeaders)

--- a/server/base/src/main/scala/korolev/server/package.scala
+++ b/server/base/src/main/scala/korolev/server/package.scala
@@ -232,8 +232,6 @@ package object server {
     val response404 = Async[F].pure[Response](Response.Http(Response.Status.NotFound, None, Seq.empty))
 
     val service: PartialFunction[Request[F], F[Response]] = {
-      case request if request.path == Root || config.router.toState.isDefinedAt(request.path) =>
-        renderStatic(request)
       case Request(Root / "static", _, _, _, _) => response404
       case Request(path, _, _, _, _) if path.startsWith("static") =>
         val fsPath = path.toString
@@ -364,6 +362,8 @@ package object server {
             }
           )
         }
+      case request if request.path == Root || config.router.toState.isDefinedAt(request.path) =>
+        renderStatic(request)
       case _ => response404
     }
 


### PR DESCRIPTION
Fixes #268