### PR TITLE
proposal to improve UX of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Korolev runs a single-page application on the server side, keeping in the browse
  
 ## Documentation
 
-* [User guide](https://fomkin.org/korolev/user-guide.html) [(download PDF)](https://fomkin.org/korolev/user-guide.pdf)
+* [User guide (open site)](https://fomkin.org/korolev/user-guide.html), [(download PDF)](https://fomkin.org/korolev/user-guide.pdf)
 * [API overview](https://www.javadoc.io/doc/com.github.fomkin/korolev_2.12/0.12.0) 
 
 ## Tools


### PR DESCRIPTION
If you have an idea how to do it better, please change it.

Currently it is not obvious that there are 2 links. One to web-site and the other to PDF.
It can be misleading currently because one can perceive `(download PDF)` as description or explanation to the text on the left. 

