### PR TITLE
Improve default connection lost widget positioning

### DIFF
--- a/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
+++ b/server/base/src/main/scala/korolev/server/KorolevServiceConfig.scala
@@ -42,8 +42,8 @@ object KorolevServiceConfig {
   def defaultConnectionLostWidget[MiscType]: Document.Node[MiscType] = {
     val dsl = new SymbolDsl[MiscType]()
     import dsl._
-    'div('style /= "position: absolute; top: 0; left: 0; right: 0;" +
-                   "background-color: yellow; border-bottom: 1px solid black; padding: 10px;",
+    'div('style /= "position: fixed; top: 0; left: 0; right: 0;" +
+                   "background-color: lightyellow; border-bottom: 1px solid black; padding: 10px;",
       "Connection lost. Waiting to resume."
     )
   }


### PR DESCRIPTION
Now it looks like this and is visible even if viewport is scrolled.
![image](https://user-images.githubusercontent.com/8080251/63777869-89212a80-c8ec-11e9-969f-9f18a48f6e1e.png)
