### PR TITLE
Close #391: PathAndQuery have bad performance in some cases

### DIFF
--- a/modules/web/src/test/scala/korolev/web/PathAndQuerySpec.scala
+++ b/modules/web/src/test/scala/korolev/web/PathAndQuerySpec.scala
@@ -22,6 +22,11 @@ class PathAndQuerySpec extends AnyFlatSpec with Matchers {
     path shouldBe Root / "page" / "1" :? "k1" -> "v1"
   }
 
+  ".fromString" should "parse path with parameter without value" in {
+    val path = PathAndQuery.fromString("/page/1?k1")
+    path shouldBe Root / "page" / "1" :? "k1" -> ""
+  }
+
   ".fromString" should "parse path with many parameters" in {
     val path = PathAndQuery.fromString("/page/1?k1=v1&k2=v2&k3=v3&k4=v4")
     path shouldBe Root / "page" / "1" :? "k1" -> "v1" :& "k2" -> "v2" :& "k3" -> "v3" :& "k4" -> "v4"
@@ -121,17 +126,6 @@ class PathAndQuerySpec extends AnyFlatSpec with Matchers {
 
     pf(path) shouldBe true
   }
-
-//  "path matching" should "correct exact match parameter" in {
-//    val path = Root / "test" :? "k1" -> "v1" :& "k2" -> "v2" :& "k3" -> "v3"
-//
-//    val pf: PartialFunction[PathAndQuery, (String, String, String)] = {
-//      case Root / "test" :?? (("k1", v1), ("k2", v2), ("k3", v3)) =>
-//        (v1, v2, v3)
-//    }
-//
-//    pf(path) shouldBe ("v1", "v2", "v3")
-//  }
 
   "path matching" should "correct exact match ignore parameters" in {
     val path = Root / "test" :? "k1" -> "v1"


### PR DESCRIPTION
JMH Results before code changes

```
[info] Benchmark                                       Mode  Cnt          Score          Error  Units
[info] MkStringPerformanceTest.Test_01_asPath         thrpt    5  235619889.558 ± 50245889.395  ops/s
[info] MkStringPerformanceTest.Test_02_startsWith     thrpt    5   47614828.935 ±  4714208.118  ops/s
[info] MkStringPerformanceTest.Test_03_endWith        thrpt    5  167203907.526 ± 37479577.102  ops/s
[info] MkStringPerformanceTest.Test_04_mkString       thrpt    5    1612761.852 ±    59163.818  ops/s
[info] MkStringPerformanceTest.Test_05_slashUnapply   thrpt    5  145609612.353 ± 22383248.229  ops/s
[info] MkStringPerformanceTest.Test_06_paramsUnapply  thrpt    5   50365500.455 ±  6462452.097  ops/s
[info] MkStringPerformanceTest.Test_07_fromString     thrpt    5    1433806.483 ±    59028.321  ops/s
[info] MkStringPerformanceTest.Test_08_reverse        thrpt    5   15749980.200 ±  1562979.327  ops/s
[info] MkStringPerformanceTest.Test_09_$plus$plus     thrpt    5   10532320.629 ±  1150295.409  ops/s
```

JMH Results after changes

```
[info] Benchmark                                       Mode  Cnt          Score          Error  Units
[info] MkStringPerformanceTest.Test_01_asPath         thrpt    5  555750463.875 ± 72971946.639  ops/s
[info] MkStringPerformanceTest.Test_02_startsWith     thrpt    5  103077330.566 ± 14805262.719  ops/s
[info] MkStringPerformanceTest.Test_03_endWith        thrpt    5  249995248.348 ±  5259383.326  ops/s
[info] MkStringPerformanceTest.Test_04_mkString       thrpt    5    3041792.424 ±    84397.082  ops/s
[info] MkStringPerformanceTest.Test_05_slashUnapply   thrpt    5  167713501.335 ±  4117317.782  ops/s
[info] MkStringPerformanceTest.Test_06_paramsUnapply  thrpt    5   60801311.310 ±  8101200.092  ops/s
[info] MkStringPerformanceTest.Test_07_fromString     thrpt    5    2388606.268 ±   191506.135  ops/s
[info] MkStringPerformanceTest.Test_08_reverse        thrpt    5  119337468.895 ±  2329843.960  ops/s
[info] MkStringPerformanceTest.Test_09_$plus$plus     thrpt    5   39640353.723 ±  3172025.020  ops/s
```