### PR TITLE
Fix support for ZStreams that use managed resources

### DIFF
--- a/interop/zio-http/src/main/scala/korolev/zio/http/ZioHttpKorolev.scala
+++ b/interop/zio-http/src/main/scala/korolev/zio/http/ZioHttpKorolev.scala
@@ -191,7 +191,7 @@ class ZioHttpKorolev[R] {
       case HttpData.StreamData(zStream) =>
         zStream.toKorolev(eff).map { kStream =>
           kStream.map(bytes => Bytes.wrap(bytes.toArray))
-        }
+        }.useNow
     }
   }
 


### PR DESCRIPTION
Make .toKorolev work for a ZStream that uses managed resources. The resources should only be released after the Korolev stream has been consumed completely.

I encountered this issue when trying to stream a file directly to the frontend. The file input stream should only be closed after the download is completed