### PR TITLE
Make .toKorolev work for a ZStream that uses managed resources. The r…

### DIFF
--- a/interop/zio-http/src/main/scala/korolev/zio/http/ZioHttpKorolev.scala
+++ b/interop/zio-http/src/main/scala/korolev/zio/http/ZioHttpKorolev.scala
@@ -191,7 +191,7 @@ class ZioHttpKorolev[R] {
       case HttpData.StreamData(zStream) =>
         zStream.toKorolev(eff).map { kStream =>
           kStream.map(bytes => Bytes.wrap(bytes.toArray))
-        }
+        }.useNow
     }
   }
 

--- a/interop/zio-streams/src/main/scala/korolev/zio/streams/package.scala
+++ b/interop/zio-streams/src/main/scala/korolev/zio/streams/package.scala
@@ -1,8 +1,9 @@
 package korolev.zio
 
-import korolev.effect.{Effect => KorolevEffect, Stream => KorolevStream}
+import korolev.effect.{Effect as KorolevEffect, Stream as KorolevStream}
 import zio.stream.ZStream
-import zio.{Chunk, Exit, FiberFailure, RIO, Runtime, ZIO}
+import zio.{Chunk, Exit, FiberFailure, RIO, Runtime, ZIO, ZManaged}
+
 import scala.concurrent.ExecutionContext
 
 
@@ -24,14 +25,11 @@ package object streams {
 
     type F[A] = RIO[R, A]
 
-    def toKorolev(implicit eff: KorolevEffect[F]): F[KorolevStream[F, Seq[O]]] = {
-      (for {
+    def toKorolev(implicit eff: KorolevEffect[F]): ZManaged[R, Throwable, KorolevStream[F, Seq[O]]] =
+      for {
         runtime <- ZIO.runtime[R].toManaged_
         pull <- stream.process
-      } yield {
-        new ZKorolevStream(runtime, pull)
-      }).useNow
-    }
+      } yield new ZKorolevStream(runtime, pull)
   }
 
   private[streams] class ZKorolevStream[R, O]

--- a/interop/zio-streams/src/test/scala/korolev/zio/streams/ZIOStreamsInteropTest.scala
+++ b/interop/zio-streams/src/test/scala/korolev/zio/streams/ZIOStreamsInteropTest.scala
@@ -62,7 +62,7 @@ class ZIOStreamsInteropTest  extends AsyncFlatSpec with Matchers {
     val io = ZStream.fromIterable(v1)
       .concat(ZStream.fromIterable(v2)) // concat need for multiple chunks test
       .toKorolev
-      .flatMap { (korolevStream: KorolevStream[Task, Seq[Int]]) =>
+      .use { (korolevStream: KorolevStream[Task, Seq[Int]]) =>
         korolevStream
           .unchunk
           .fold(Vector.empty[Int])((acc, value) => acc :+ value)


### PR DESCRIPTION
…esources should only be released after the Korolev stream has been consumed completely.