### PR TITLE
Fix path concatenate

### DIFF
--- a/modules/web/src/main/scala/korolev/web/PathAndQuery.scala
+++ b/modules/web/src/main/scala/korolev/web/PathAndQuery.scala
@@ -177,13 +177,10 @@ sealed trait Path extends PathAndQuery {
     @tailrec
     def reverse(path: Path, result: Path): Path = {
       path match {
-        case p: / =>
-          if (p.prev == Root) {
-            PathAndQuery./(result, p.value)
-          } else {
-            reverse(p.prev, PathAndQuery./(result, p.value))
-          }
-        case Root => Root
+        case prev / value =>
+          reverse(prev, result / value)
+        case Root =>
+          result
       }
     }
 
@@ -194,13 +191,10 @@ sealed trait Path extends PathAndQuery {
     @tailrec
     def aux(result: Path, other: Path): Path = {
       other match {
-        case p: / =>
-          if (p.prev == Root) {
-            PathAndQuery./(result, p.value)
-          } else {
-            aux(result / p.value, p.prev)
-          }
-        case Root => tail
+        case prev / value =>
+          aux(result / value, prev)
+        case Root =>
+          result
       }
     }
 

--- a/modules/web/src/test/scala/korolev/web/PathAndQuerySpec.scala
+++ b/modules/web/src/test/scala/korolev/web/PathAndQuerySpec.scala
@@ -118,6 +118,8 @@ class PathAndQuerySpec extends AnyFlatSpec with Matchers {
     val tail = Root / "admin" / "parameters" / "edit"
 
     head ++ tail shouldBe Root / "api" / "v1" / "system" / "admin" / "parameters" / "edit"
+    head ++ Root shouldBe head
+    Root ++ tail shouldBe tail
   }
 
   ".++" should "correct concatenate complex path with query" in {


### PR DESCRIPTION
The `Path ++ Path` implementation was not correct in the `path ++ Root` case.

The **new test** with the **old code** fails:
```
Root was not equal to /(/(/(Root,api),v1),system)
ScalaTestFailureLocation: korolev.web.PathAndQuerySpec at (PathAndQuerySpec.scala:121)
Expected :/(/(/(Root,api),v1),system)
Actual   :Root
```