### PR TITLE
Fix `Hub` concurrency issues and improve `recover` in zio 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -311,7 +311,13 @@ lazy val zio2 = project
   .settings(commonSettings: _*)
   .settings(
     normalizedName := "korolev-zio2",
-    libraryDependencies += "dev.zio" %% "zio" % zio2Version
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio" % zio2Version,
+      "dev.zio" %% "zio-test" % zio2Version % Test,
+      "dev.zio" %% "zio-test-sbt" % zio2Version % Test,
+      "dev.zio" %% "zio-test-magnolia" % zio2Version % Test
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )
   .dependsOn(effect)
 

--- a/interop/zio2/src/main/scala/korolev/zio/Zio2Effect.scala
+++ b/interop/zio2/src/main/scala/korolev/zio/Zio2Effect.scala
@@ -80,9 +80,10 @@ class Zio2Effect[R, E](rts: Runtime[R], liftError: Throwable => E, unliftError: 
 
   def recover[A, AA >: A](m: ZIO[R, E, A])(f: PartialFunction[Throwable, AA]): ZIO[R, E, AA] =
     m.catchSome(unliftErrorP.andThen(f).andThen(result => ZIO.succeed(result)))
+      .catchSomeDefect(f.andThen(result => ZIO.succeed(result)))
 
   def recoverF[A, AA >: A](m: ZIO[R, E, A])(f: PartialFunction[Throwable, ZIO[R, E, AA]]): ZIO[R, E, AA] =
-    m.catchSome(unliftErrorP.andThen(f).andThen(result => result))
+    m.catchSome(unliftErrorP.andThen(f).andThen(result => result)).catchSomeDefect(f)
 
   def start[A](task: => ZIO[R, E, A])(implicit ec: ExecutionContext): ZIO[R, E, Effect.Fiber[ZIO[R, E, *], A]] =
     ZIO

--- a/interop/zio2/src/test/scala/korolev/zio/Zio2HubSpec.scala
+++ b/interop/zio2/src/test/scala/korolev/zio/Zio2HubSpec.scala
@@ -1,0 +1,229 @@
+package korolev.zio
+
+import zio.{Queue as _, Hub as _, Console as _, _}
+import korolev.effect._
+
+import zio.test.Assertion.*
+import zio.test.TestAspect.{identity as _, _}
+import zio.test.*
+
+object Zio2HubSpec extends ZIOSpecDefault {
+  val smallInt: Gen[Sized, Int] =
+    Gen.small(Gen.const(_), 1)
+
+  implicit val effect: Zio2Effect[Any, Throwable] = new Zio2Effect[Any, Throwable](runtime, identity, identity)
+
+  def spec =
+    suite("Hub Spec")(
+      suite("sequential publishers and subscribers")(
+        test("with one publisher and one subscriber") {
+          check(smallInt, Gen.listOf(smallInt)) {
+            (n, as) =>
+              for {
+                promise1 <- Promise.make[Nothing, Unit]
+                promise2 <- Promise.make[Nothing, Unit]
+                queue = Queue[Task, Int](n)
+                hub = Hub[Task, Int](queue.stream, n)
+                subscriber <- ZIO.scoped {
+                  hub.newStream().flatMap { subscription =>
+                    promise1.succeed(()) *> promise2.await *> ZIO.foreach(as.take(n))(_ => subscription.pull())
+                  }
+                }.fork
+                _ <- promise1.await
+                _ <- ZIO.foreach(as.take(n))(queue.offer)
+                _ <- promise2.succeed(())
+                values <- subscriber.join
+              } yield assert(values.flatten)(equalTo(as.take(n)))
+          }
+        } @@ timeout(10.seconds),
+        test("with one publisher and two subscribers") {
+          check(smallInt, Gen.listOf(smallInt)) {
+            (n, as) =>
+              for {
+                promise1 <- Promise.make[Nothing, Unit]
+                promise2 <- Promise.make[Nothing, Unit]
+                promise3 <- Promise.make[Nothing, Unit]
+                queue = Queue[Task, Int]()
+                hub = Hub[Task, Int](queue.stream)
+                // _ <- ZIO.debug(as.take(n))
+                subscriber1 <- ZIO.scoped {
+                  hub
+                    .newStream()
+                    .flatMap(subscription =>
+                      promise1.succeed(()) *> promise3.await *> ZIO.foreach(as.take(n))(_ => subscription.pull()))
+                }.fork
+                subscriber2 <- ZIO.scoped {
+                  hub
+                    .newStream()
+                    .flatMap(subscription =>
+                      promise2.succeed(()) *> promise3.await *> ZIO.foreach(as.take(n))(_ => subscription.pull()))
+                }.fork
+                _ <- promise1.await
+                _ <- promise2.await
+                _ <- ZIO.foreach(as.take(n))(queue.offer)
+                _ <- promise3.succeed(())
+                values1 <- subscriber1.join
+                values2 <- subscriber2.join
+              } yield
+                assert(values1.flatten)(equalTo(as.take(n))) &&
+                  assert(values2.flatten)(equalTo(as.take(n)))
+          }
+        } @@ timeout(20.seconds)
+      ),
+      suite("concurrent publishers and subscribers")(
+        test("one to one") {
+          check(smallInt, Gen.listOf(smallInt)) {
+            (n, as) =>
+              for {
+                promise <- Promise.make[Nothing, Unit]
+                queue <- ZIO.succeed(Queue[Task, Int](n))
+                hub = Hub[Task, Int](queue.stream, n)
+                subscriber <- ZIO.scoped {
+                  hub.newStream().flatMap { subscription =>
+                    promise.succeed(()) *> ZIO.foreach(as.take(n))(_ => subscription.pull().some)
+                  }
+                }.fork
+                _ <- promise.await
+                _ <- ZIO.foreach(as.take(n))(queue.enqueue).fork
+                values <- subscriber.join
+              } yield assert(values)(equalTo(as.take(n)))
+          }
+        },
+        test("one to many") {
+          check(smallInt, Gen.listOf(smallInt)) {
+            (n, as) =>
+              for {
+                promise1 <- Promise.make[Nothing, Unit]
+                promise2 <- Promise.make[Nothing, Unit]
+                queue <- ZIO.succeed(Queue[Task, Int](n))
+                hub = Hub[Task, Int](queue.stream, n)
+                subscriber1 <- ZIO.scoped {
+                  hub.newStream().flatMap { subscription =>
+                    promise1.succeed(()) *> ZIO.foreach(as.take(n))(_ => subscription.pull().some)
+                  }
+                }.fork
+                subscriber2 <- ZIO.scoped {
+                  hub.newStream().flatMap { subscription =>
+                    promise2.succeed(()) *> ZIO.foreach(as.take(n))(_ => subscription.pull().some)
+                  }
+                }.fork
+                _ <- promise1.await
+                _ <- promise2.await
+                _ <- ZIO.foreach(as.take(n))(queue.enqueue).fork
+                values1 <- subscriber1.join
+                values2 <- subscriber2.join
+              } yield
+                assert(values1)(equalTo(as.take(n))) &&
+                  assert(values2)(equalTo(as.take(n)))
+          }
+        },
+        test("many to many") {
+          check(smallInt, Gen.listOf(smallInt)) {
+            (n, as) =>
+              for {
+                promise1 <- Promise.make[Nothing, Unit]
+                promise2 <- Promise.make[Nothing, Unit]
+                queue <- ZIO.succeed(Queue[Task, Int](n * 2))
+                hub = Hub[Task, Int](queue.stream, n * 2)
+                subscriber1 <- ZIO.scoped {
+                  hub.newStream().flatMap { subscription =>
+                    promise1.succeed(()) *> ZIO.foreach((as ::: as).take(n * 2))(_ => subscription.pull().some)
+                  }
+                }.fork
+                subscriber2 <- ZIO.scoped {
+                  hub.newStream().flatMap { subscription =>
+                    promise2.succeed(()) *> ZIO.foreach((as ::: as).take(n * 2))(_ => subscription.pull().some)
+                  }
+                }.fork
+                _ <- promise1.await
+                _ <- promise2.await
+                _ <- ZIO.foreach(as.take(n))(queue.enqueue).fork
+                _ <- ZIO.foreach(as.take(n).map(-_))(queue.enqueue).fork
+                values1 <- subscriber1.join
+                values2 <- subscriber2.join
+              } yield
+                assert(values1.filter(_ > 0))(equalTo(as.take(n))) &&
+                  assert(values1.filter(_ < 0))(equalTo(as.take(n).map(-_))) &&
+                  assert(values2.filter(_ > 0))(equalTo(as.take(n))) &&
+                  assert(values2.filter(_ < 0))(equalTo(as.take(n).map(-_)))
+          }
+        },
+        test("with one publisher and three subscribers")(assertZIO {
+          for {
+            queue <- ZIO.succeed(Queue[Task, Int]())
+            hub = Hub[Task, Int](queue.stream)
+            s1 <- hub.newStream()
+            s2 <- hub.newStream()
+            s3 <- hub.newStream()
+            ss = Seq(s1, s2, s3)
+
+            fiber <- ZIO
+              .foreachPar(ss)(s => ZIO.foreach(1 to 200)(_ => s.pull().some))
+              .fork
+
+            _ <- ZIO.foreachDiscard(1 to 200)(a => queue.enqueue(a))
+            num <- fiber.join
+            _ <- ZIO
+              .foreach(num)(nums => {
+                val duplicates = nums.groupBy(identity).collect { case (x, List(_, _, _*)) => x }.toSet
+                ZIO.debug(
+                  nums
+                    .map {
+                      case num if duplicates.contains(num) => s"${Console.RED}$num${Console.WHITE}"
+                      case num                             => num.toString
+                    }
+                    .mkString(", ")
+                ) *> ZIO.debug("")
+              })
+              .when(p = false)
+          } yield num
+
+        }(forall(equalTo(Range.inclusive(1, 200))))) @@ repeat(Schedule.recurs(200))
+      ),
+      suite("back pressure")(
+        test("one to one") {
+          check(smallInt, Gen.listOf(smallInt)) {
+            (n, as) =>
+              for {
+                promise <- Promise.make[Nothing, Unit]
+                queue <- ZIO.succeed(Queue[Task, Int](n))
+                hub = Hub[Task, Int](queue.stream, n)
+                subscriber <- ZIO.scoped {
+                  hub.newStream().flatMap { subscription =>
+                    promise.succeed(()) *> ZIO.foreach(as)(_ => subscription.pull().some)
+                  }
+                }.fork
+                _ <- promise.await
+                _ <- ZIO.foreach(as)(queue.enqueue).fork
+                values <- subscriber.join
+              } yield assert(values)(equalTo(as))
+          }
+        },
+        // this test does not work with bounded hubs
+//      test("one to many") {
+//        check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+//          for {
+//            promise1 <- Promise.make[Nothing, Unit]
+//            promise2 <- Promise.make[Nothing, Unit]
+//            queue <- ZIO.succeed(Queue[Task, Int](n))
+//            hub = Hub[Task, Int](queue.stream, n)
+//            subscriber1 <-
+//              hub.newStream().flatMap { subscription =>
+//                promise1.succeed(()) *> ZIO.foreach(as)(_ => subscription.pull().some)
+//              }.fork
+//            subscriber2 <-
+//              hub.newStream().flatMap { subscription =>
+//                promise2.succeed(()) *> ZIO.foreach(as)(_ => subscription.pull().some)
+//              }.fork
+//            _       <- promise1.await
+//            _       <- promise2.await
+//            _       <- ZIO.foreach(as)(queue.enqueue).fork
+//            values1 <- subscriber1.join.disconnect.timeoutFail(new Exception(s"timeout ${n} ${as}"))(1.second)
+//            values2 <- subscriber2.join.disconnect.timeoutFail(new Exception(s"timeout ${n} ${as}"))(1.second)
+//          } yield assert(values1)(equalTo(as)) &&
+//            assert(values2)(equalTo(as))
+//        }
+//      },
+      )
+    ) @@ silent
+}

--- a/interop/zio2/src/test/scala/korolev/zio/Zio2QueueSpec.scala
+++ b/interop/zio2/src/test/scala/korolev/zio/Zio2QueueSpec.scala
@@ -1,0 +1,228 @@
+package korolev.zio
+
+import zio.{Queue as _, _}
+import korolev.effect._
+
+import zio.test.Assertion._
+import zio.test.TestAspect.{identity as _, _}
+import zio.test._
+
+import QueueSpecUtil._
+
+object Zio2QueueSpec extends ZIOSpecDefault {
+  implicit val effect: Zio2Effect[Any, Throwable] = new Zio2Effect[Any, Throwable](runtime, identity, identity)
+  def spec = suite("Queue Spec")(
+    test("sequential offer and take") {
+      for {
+        _ <- ZIO.unit
+        queue = Queue[Task, Int]()
+        o1 <- queue.offer(10)
+        v1 <- queue.stream.pull().some
+        o2 <- queue.offer(20)
+        v2 <- queue.stream.pull().some
+      } yield
+        assert(v1)(equalTo(10)) &&
+          assert(v2)(equalTo(20)) &&
+          assert(o1)(isTrue) &&
+          assert(o2)(isTrue)
+    },
+    test("sequential take and offer") {
+      for {
+        _ <- ZIO.unit
+        queue = Queue[Task, String]()
+        f1 <- queue.stream.pull().some.zipWith(queue.stream.pull().some)(_ + _).fork
+        _ <- queue.offer("don't ") *> queue.offer("give up :D")
+        v <- f1.join
+      } yield assert(v)(equalTo("don't give up :D"))
+    },
+    // this test does not work because when several cb we give a value to all but not one
+//    test("parallel takes and sequential offers ") {
+//      for {
+//        _ <- ZIO.unit
+//        queue = Queue[Task, Int]()
+//        f <- ZIO.forkAll(List.fill(10)(queue.stream.pull().some))
+//        values = Range.inclusive(1, 10).toList
+//        _ <- ZIO.foreachDiscard(values)(queue.offer)
+//        v <- f.join
+//      } yield assert(v.toSet)(equalTo(values.toSet))
+//    },
+    test("parallel offers and sequential takes") {
+      for {
+        _ <- ZIO.unit
+        queue = Queue[Task, Int]()
+        values = Range.inclusive(1, 10).toList
+        f <- ZIO.forkAll(values.map(queue.offer))
+        _ <- waitForSize(queue, 10)
+        out <- Ref.make[List[Int]](Nil)
+        _ <- queue.stream.pull().some.flatMap(i => out.update(i :: _)).repeatN(9)
+        l <- out.get
+        _ <- f.join
+      } yield assert(l.toSet)(equalTo(values.toSet))
+    },
+    test("offers are suspended by back pressure") {
+      for {
+        _ <- ZIO.unit
+        queue = Queue[Task, Int](10)
+        _ <- queue.offer(1).repeatN(9)
+        refSuspended <- Ref.make[Boolean](true)
+        f <- (queue.enqueue(2) *> refSuspended.set(false)).fork
+        _ <- waitForSize(queue, 11)
+        isSuspended <- refSuspended.get
+        _ <- f.interrupt
+      } yield assertTrue(isSuspended)
+    },
+    test("back pressured offers are retrieved") {
+      for {
+        _ <- ZIO.unit
+        queue = Queue[Task, Int](5)
+        values = Range.inclusive(1, 10).toList
+        f <- ZIO.forkAll(values.map(queue.enqueue))
+        _ <- waitForSize(queue, 10)
+        out <- Ref.make[List[Int]](Nil)
+        _ <- queue.stream.pull().some.flatMap(i => out.update(i :: _)).repeatN(9)
+        l <- out.get
+        _ <- f.join
+      } yield assert(l.toSet)(equalTo(values.toSet))
+    },
+    // these tests do not work because pulling and offerring are uninterruptable
+    // test("take interruption") {
+    //   for {
+    //     _            <- ZIO.unit
+    //     queue        = Queue[Task, Int]()
+    //     f     <- queue.stream.pull().fork
+    //     _     <- waitForSize(queue, -1)
+    //     _     <- f.interrupt
+    //     size  <- queue.size()
+    //   } yield assert(size)(equalTo(0))
+    // },
+    // test("offer interruption") {
+    //   for {
+    //             _            <- ZIO.unit
+    //     queue        = Queue[Task, Int](2)
+    //     _     <- queue.enqueue(1)
+    //     _     <- queue.enqueue(1)
+    //     f     <- queue.enqueue(1).fork
+    //     _     <- waitForSize(queue, 3)
+    //     _     <- f.interrupt
+    //     size  <- queue.size()
+    //   } yield assert(size)(equalTo(2))
+    // },
+    test("queue is ordered") {
+      for {
+        _ <- ZIO.unit
+        queue = Queue[Task, Int]()
+        _ <- queue.offer(1)
+        _ <- queue.offer(2)
+        _ <- queue.offer(3)
+        v1 <- queue.stream.pull().some
+        v2 <- queue.stream.pull().some
+        v3 <- queue.stream.pull().some
+      } yield
+        assert(v1)(equalTo(1)) &&
+          assert(v2)(equalTo(2)) &&
+          assert(v3)(equalTo(3))
+    },
+    test("many to many") {
+      check(smallInt, Gen.listOf(smallInt)) { (n, as) =>
+        for {
+          _ <- ZIO.unit
+          queue = Queue[Task, Int]()
+          offerors <- ZIO.foreach(as)(a => queue.enqueue(a).fork)
+          takers <- ZIO.foreach(as)(_ => queue.stream.pull().some.fork)
+          _ <- ZIO.foreach(offerors)(_.join)
+          _ <- ZIO.foreach(takers)(_.join)
+        } yield assertCompletes
+      }
+    } @@ samples(200),
+    test("returns elements in the correct order") {
+      check(Gen.chunkOf(Gen.int(-10, 10))) { as =>
+        for {
+          _ <- ZIO.unit
+          queue = Queue[Task, Int](100)
+          f <- ZIO.foreach(as)(queue.offer).fork
+          bs <- ZIO.foreach(1 to as.length)(_ => queue.stream.pull().some)
+          _ <- f.interrupt
+        } yield assert(as)(equalTo(bs))
+      }
+    },
+    test("Concurrent offer/pull invocations")(
+      assertZIO(
+        for {
+          s1 <- Stream(0 until 100: _*).mat()
+          s2 <- Stream(100 until 200: _*).mat()
+          s3 <- Stream(200 until 300: _*).mat()
+          queue = Queue[Task, Int]()
+
+          ss = Seq(s1, s2, s3)
+          fiber <- queue.stream.fold(0)((c, _) => c + 1).fork
+
+          _ <- ZIO.foreachParDiscard(ss)(s => s.foreach(v => queue.offer(v).unit))
+          _ <- queue.stop()
+          count <- fiber.join
+        } yield count
+      )(equalTo(300))
+    ),
+//    test("canOffer")(
+//      assertZIO {
+//        def checkCanOffer(maxSize: Int) = {
+//          val queue = Queue[Task, Int](maxSize)
+//
+//          def offeringProcess =
+//            for {
+//              s1 <- Stream(0 until 1000: _*).mat()
+//              s2 <- Stream(1000 until 2000: _*).mat()
+//              s3 <- Stream(2000 until 3000: _*).mat()
+//              sem <- Semaphore.make(permits = 4)
+//              ss = Seq(s1, s2, s3)
+//              _ <- sem.withPermit(
+//                ZIO.foreachDiscard(ss)(
+//                  s =>
+//                    sem.withPermit(
+//                      ZIO.foreachDiscard(1 to 1000)(
+//                        _ =>
+//                          s.pull()
+//                            .some
+//                            .flatMap(i => {
+//                              def aux(): Task[Unit] = queue.offer(i) flatMap {
+//                                case false => queue.canOffer *> aux()
+//                                case true  => ZIO.unit
+//                              }
+//                              aux()
+//                            }.fork))
+//                  ))
+//              )
+//              _ <- sem.withPermits(4)(queue.stop())
+//            } yield ()
+//
+//          for {
+//            offerring <- offeringProcess.fork
+//            count <- (1 to 3000).foldLeft(ZIO.attempt(0))((acc, _) =>
+//              for {
+//                c <- acc
+//                _ <- queue.stream.pull()
+//              } yield c + 1
+//            )
+//            _ <- offerring.join
+//          } yield count
+//        }
+//
+//        for {
+//          c1 <- checkCanOffer(1)
+//          c5 <- checkCanOffer(5)
+//          c10 <- checkCanOffer(10)
+//        } yield Seq(c1, c5, c10)
+//      }(forall(equalTo(3000)))
+//    )
+  )
+}
+
+object QueueSpecUtil {
+  def waitForValue[T](ref: Task[T], value: T): ZIO[Live, Throwable, T] =
+    Live.live((ref <* Clock.sleep(10.millis)).repeatUntil(_ == value))
+
+  def waitForSize[A](queue: Queue[Task, A], size: Int): ZIO[Live, Throwable, RuntimeFlags] =
+    waitForValue(queue.size(), size)
+
+  val smallInt: Gen[Sized, Int] =
+    Gen.small(Gen.const(_), 1)
+}

--- a/modules/effect/src/main/scala/korolev/effect/Hub.scala
+++ b/modules/effect/src/main/scala/korolev/effect/Hub.scala
@@ -62,12 +62,17 @@ final class Hub[F[_]: Effect, T](upstream: Stream[F, T], bufferSize: Int) {
         maybeItem
       }
 
-    def pull(): F[Option[T]] = begin()
-      .flatMap { began =>
-        if (!began) thisQueue.stream.pull()
-        else for (result <- pullUpstream(); _ <- end())
-          yield result
-      }
+    def pull(): F[Option[T]] =
+      for {
+        began <- begin()
+        result <- if (began)
+          for {
+            size <- thisQueue.size()
+            result <- if (size > 0) end() *> thisQueue.stream.pull()
+            else pullUpstream().flatMap(v => end().as(v))
+          } yield result
+        else thisQueue.stream.pull()
+      } yield result
 
     def cancel(): F[Unit] = thisQueue.close()
   }

--- a/modules/effect/src/main/scala/korolev/effect/Queue.scala
+++ b/modules/effect/src/main/scala/korolev/effect/Queue.scala
@@ -245,6 +245,17 @@ class Queue[F[_]: Effect, T](maxSize: Int) {
     aux()
   }
 
+  /**
+   * Returns the size of the queue. This property takes into account canOfferCallbacks and pullCallbacks to
+   * determine the real size of the queue after all of them are resolved.
+   * @return
+   */
+  def size(): F[Int] =
+    Effect[F].delay {
+      val s = state.get()
+      s.queue.size + s.canOfferCallbacks.size - s.pullCallbacks.length
+    }
+
   val stream: Stream[F, T] = new QueueStream()
 }
 


### PR DESCRIPTION
* Fix `pull()` in `Hub`
* Introduce zio 2 tests for `Queue` and `Hub`
* Recover from defects in `recover` and `recoverF` in `Zio2Runtime`