### PR TITLE
Fix MatchError in PathAndQuery.param

### DIFF
--- a/modules/web/src/main/scala/korolev/web/PathAndQuery.scala
+++ b/modules/web/src/main/scala/korolev/web/PathAndQuery.scala
@@ -119,6 +119,7 @@ sealed trait PathAndQuery {
         case :&(_, (k, v)) if k == name => Some(v)
         case :&(prev, _)                => aux(prev)
         case _ :? tpl if tpl._1 == name => Some(tpl._2)
+        case _ :? _                     => None
       }
     }
 

--- a/modules/web/src/test/scala/korolev/web/PathAndQuerySpec.scala
+++ b/modules/web/src/test/scala/korolev/web/PathAndQuerySpec.scala
@@ -135,6 +135,16 @@ class PathAndQuerySpec extends AnyFlatSpec with Matchers {
     path.reverse shouldBe Root / "system" / "v1" / "api"
   }
 
+  ".params" should "return Some for an existing param" in {
+    val head = Root :? "k1" -> "v1"
+    head.param("k1") shouldBe Some("v1")
+  }
+
+  ".params" should "return None for a missing param" in {
+    val head = Root :? "k1" -> "v1"
+    head.param("k2") shouldBe None
+  }
+
   "path matching" should "correct extract parameters as a Map[String, String]" in {
     val path = Root / "test" :? "k1" -> "v1"
 


### PR DESCRIPTION
`PathAndQuery.param` throws a `MatchError` if the parameter is missing. See added test case for reproduction.