### PR TITLE
Add two tests for Queue and Hub

### DIFF
--- a/interop/zio2/src/test/scala/korolev/zio/Zio2QueueSpec.scala
+++ b/interop/zio2/src/test/scala/korolev/zio/Zio2QueueSpec.scala
@@ -173,7 +173,7 @@ object Zio2QueueSpec extends ZIOSpecDefault {
           _ <- canOffer.join
         } yield ()
       }(isUnit)
-    ) @@ diagnose(5.seconds)
+    )
   )
 }
 


### PR DESCRIPTION
Previously there were commented tests that were not adapted to the specific implementation of `Queue` and `Hub`. This PR fixes them.